### PR TITLE
Adding Poll Feature to Mapuro Bot

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -20,6 +20,8 @@ async def on_ready():
 client.load_extension("src.exts.shenanigans.shenanigans")
 client.load_extension("src.exts.shenanigans.ask")
 client.load_extension("src.exts.shenanigans.react")
+client.load_extension("src.exts.utilities.utility")
+client.load_extension("src.exts.utilities.poll")
 
 # Start the bot
 client.start(env.discord_bot_token)

--- a/src/exts/utilities/poll.py
+++ b/src/exts/utilities/poll.py
@@ -44,8 +44,6 @@ class Poll(Extension):
         for emoji in poll_choices.keys():
             await message.add_reaction(emoji=f'{emoji}')
 
-        ctx.channel.fetch_message()
-
 
 def setup(bot):
     Poll(bot)

--- a/src/exts/utilities/poll.py
+++ b/src/exts/utilities/poll.py
@@ -1,0 +1,51 @@
+from interactions import *
+from src.exts.utilities.utility import Utility
+
+
+class Poll(Extension):
+    @Utility.info.subcommand(sub_cmd_name='poll',
+                             sub_cmd_description='Create a poll for others to react')
+    @slash_option(name='question',
+                  description='Your question to everyone',
+                  opt_type=OptionType.STRING,
+                  required=True)
+    @slash_option(name='choices',
+                  description='Choices separated by "|" for each <emoji>~<choice>. Custom emoji is '
+                              'optional. 🔮~A|🎃~B|C. Limit 10',
+                  opt_type=OptionType.STRING,
+                  required=True)
+    async def poll(self, ctx: SlashContext, question: str, choices: str):
+        default_emojis = [':zero:', ':one:', ':two:', ':three:', ':four:', ':five:', ':six:', ':seven:', ':eight:',
+                          ':nine:', ':keycap_ten:']
+        emojis_index = 0
+        poll_choices = {}  # Key: Emoji, Value: Choice String
+
+        # Map out the user input into a dictionary. Limiting it to 11 choices
+        for choice in choices.split("|")[:11]:
+            c = choice.split('~')
+            # Handles if user doesn't provide an emoji
+            if len(c) == 1:
+                poll_choices[default_emojis[emojis_index]] = c[0]
+                emojis_index += 1
+            else:
+                poll_choices[c[0].strip()] = c[1]
+
+        # Build the printout of poll choices for the embed
+        embed_choices = ''
+        for emoji, val in poll_choices.items():
+            embed_choices += f'{emoji} {val}\n'
+
+        poll_embed = Embed(title=f'**{question}**',
+                           description=embed_choices,
+                           color=Color.from_rgb(98, 242, 175))
+        message = await ctx.send(embeds=poll_embed)
+
+        # After sending the msg, add a default react for each of the choices
+        for emoji in poll_choices.keys():
+            await message.add_reaction(emoji=f'{emoji}')
+
+        ctx.channel.fetch_message()
+
+
+def setup(bot):
+    Poll(bot)

--- a/src/exts/utilities/utility.py
+++ b/src/exts/utilities/utility.py
@@ -1,0 +1,30 @@
+from interactions import *
+import resources.env as env
+
+
+def get_cmd_information():
+    return \
+        '''### `poll` - Create a poll 
+- `question` - Your question to everybody 
+- `choices` - Choices separated by g"|" and with "~" for each <emoji>~<choice> if a custom emoji is desired. 🔮~A|🎃~B|C. Limit 10'''
+
+
+class Utility(Extension):
+
+    @slash_command(name='util',
+                   description='Utility Commands for something useful perhaps',
+                   sub_cmd_name='info',
+                   sub_cmd_description='Info on available utility commands',
+                   scopes=env.discord_guild_ids)
+    async def info(self, ctx: SlashContext):
+        information = get_cmd_information()
+
+        embed = Embed(title='<a:bugcat_keyboard_smash:1201274359705239635> **Utility Commands Info** '
+                            '<a:bugcat_keyboard_smash:1201274359705239635>',
+                      description=information,
+                      color=Color.from_rgb(98, 242, 175))
+        await ctx.send(embeds=embed)
+
+
+def setup(bot):
+    Utility(bot)

--- a/src/exts/utilities/utility.py
+++ b/src/exts/utilities/utility.py
@@ -5,8 +5,9 @@ import resources.env as env
 def get_cmd_information():
     return \
         '''### `poll` - Create a poll 
-- `question` - Your question to everybody 
-- `choices` - Choices separated by g"|" and with "~" for each <emoji>~<choice> if a custom emoji is desired. 🔮~A|🎃~B|C. Limit 10'''
+- `question` - Your question to everybody
+- `choices` - Choices separated by g"|" and with "~" for each <emoji>~<choice> if a custom emoji is desired such as 🍔~A|🍝~B|C. Limit 10
+/util poll question| What item? choices| 🔮~Globe|🎃~Pumpkin|Cookie'''
 
 
 class Utility(Extension):


### PR DESCRIPTION
# Poll Feature

## Description
Adding the ability for the user to create a poll by providing a question and some choices with some custom choiced emojis or with the default emojis. Up to 11 choices can be given.

Users will run the command with arguments as follows:
1. `poll` - Create a poll
&nbsp; - `question` - Your question to everybody
&nbsp;  - `choices` - Choices separated by "|" and with "\~" for each <emoji>~<choice> if a custom emoji is desired. 🔮\~A|🎃\~B|C. Limit 10

2. `info` - Provides info of utility commands such as `poll`

**Breaking News** - Bot can use animated emojis. Just need to provide it the id such as `<a:bugcat_keyboard_smash:1201274359705239635>` used in the `info` command


## Samples
### Info Command
<img src="https://github.com/AE-Mapuro/Maple-Bot/assets/8675478/dcb5f364-c38e-4135-a508-aac66e026e75" width="75%">

### Custom Emojis
<img src="https://github.com/AE-Mapuro/Maple-Bot/assets/8675478/542f8a44-2232-4aaf-93f3-8d51480fdcc2" width="35%">

### Custom + Default Emojis
<img src="https://github.com/AE-Mapuro/Maple-Bot/assets/8675478/59f44f58-9fb9-473d-ab9b-da88352df863" width="35%">

### Default Emojis
<img src="https://github.com/AE-Mapuro/Maple-Bot/assets/8675478/354843c7-2366-44eb-8c1c-9199b306ca23" width="60%">